### PR TITLE
Modified transactional barriers in form 43 and and treasury pdf gener…

### DIFF
--- a/src/main/java/org/fenixedu/ulisboa/specifications/ui/firstTimeCandidacy/DocumentsPrintController.java
+++ b/src/main/java/org/fenixedu/ulisboa/specifications/ui/firstTimeCandidacy/DocumentsPrintController.java
@@ -73,6 +73,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import pt.ist.fenixframework.Atomic;
+import pt.ist.fenixframework.Atomic.TxMode;
 
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.pdf.PdfCopyFields;
@@ -170,7 +171,7 @@ public class DocumentsPrintController extends FenixeduUlisboaSpecificationsBaseC
 
     private static final String CGD_PERSONAL_INFORMATION_PDF_PATH = "candidacy/firsttime/CGD43.pdf";
 
-    @Atomic
+    @Atomic(mode = TxMode.WRITE)
     private void printRegistrationDeclaration(StudentCandidacy candidacy, Registration registration) {
         DocumentRequestCreator documentRequestCreator = new DocumentRequestCreator(registration);
         documentRequestCreator.setChosenServiceRequestType(ServiceRequestType.findUnique(AcademicServiceRequestType.DOCUMENT,
@@ -196,7 +197,6 @@ public class DocumentsPrintController extends FenixeduUlisboaSpecificationsBaseC
         documentRequest.delivered();
     }
 
-    @Atomic
     private void printModel43(StudentCandidacy candidacy) {
         Person person = Authenticate.getUser().getPerson();
 
@@ -222,12 +222,12 @@ public class DocumentsPrintController extends FenixeduUlisboaSpecificationsBaseC
         appendSummaryFile(stream.toByteArray(), candidacy);
     }
 
-    @Atomic
     private void printTuitionPaymentPlan(StudentCandidacy candidacy, Registration registration) {
         byte[] tuitionPlanbytes = DocumentPrinter.printRegistrationTuititionPaymentPlan(registration, DocumentPrinter.PDF);
         appendSummaryFile(tuitionPlanbytes, candidacy);
     }
 
+    @Atomic(mode = TxMode.WRITE)
     private static void appendSummaryFile(byte[] pdfByteArray, StudentCandidacy studentCandidacy) {
         CandidacySummaryFile existingSummary = studentCandidacy.getSummaryFile();
         if (existingSummary != null) {


### PR DESCRIPTION
…ations.

Since transactions will always write, modified Atomics to not use speculative
read but rather write mode so we avoid tx restart

You are creating the PDFs inside transactions, that is only needed in the academic documents since those are domain.  @JoaoRoxoNeves , @NunoPinheiro do you agree with these changes?