### PR TITLE
Split shifts column of enrolments report into several columns

### DIFF
--- a/src/main/resources/resources/FenixeduUlisboaSpecificationsResources_en.properties
+++ b/src/main/resources/resources/FenixeduUlisboaSpecificationsResources_en.properties
@@ -1921,6 +1921,7 @@ label.Enrolment.grade=Grade
 label.Enrolment.executionPeriod=Semester
 label.Enrolment.improvementOnly=Improvement Only?
 label.Enrolment.shifts=Shifts
+label.Enrolment.shift=Shift - {0}
 label.Enrolment.curriculumGroup=Group
 label.Enrolment.numberOfEnrolments=Number of Enrolments
 label.Enrolment.gradeImproved=Grade Improved?

--- a/src/main/resources/resources/FenixeduUlisboaSpecificationsResources_pt.properties
+++ b/src/main/resources/resources/FenixeduUlisboaSpecificationsResources_pt.properties
@@ -2246,6 +2246,7 @@ label.Enrolment.grade=Nota
 label.Enrolment.executionPeriod=Semestre
 label.Enrolment.improvementOnly=Melhoria Apenas?
 label.Enrolment.shifts=Turnos
+label.Enrolment.shift=Turno - {0}
 label.Enrolment.curriculumGroup=Grupo
 label.Enrolment.numberOfEnrolments=Número de Inscrições
 label.Enrolment.gradeImproved=Melhorou Nota?


### PR DESCRIPTION
Split shifts column of enrolments report into several columns, one per shift type.
The shift types PRATICA, TEORICO_PRATICA and RESERVA are explicitly ignored.
